### PR TITLE
fragmentを出した際にfabを非表示にして誤クリックを防止

### DIFF
--- a/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/UI/Script/BlockSelectFragment.java
+++ b/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/UI/Script/BlockSelectFragment.java
@@ -25,7 +25,8 @@ public class BlockSelectFragment extends Fragment implements ScriptContract.Sele
     public BlockSelectFragment() {
     }
 
-    private MyListener mListener;
+    private BlockClickListener mListener;
+    private OutSideClickListener outSideClickListener;
 
     @Nullable
     @Override
@@ -37,6 +38,7 @@ public class BlockSelectFragment extends Fragment implements ScriptContract.Sele
             @Override
             public void onClick(View view) {
                 getFragmentManager().beginTransaction().remove(BlockSelectFragment.this).commit();
+                outSideClickListener.onClickOutSide();
             }
         });
 
@@ -118,8 +120,12 @@ public class BlockSelectFragment extends Fragment implements ScriptContract.Sele
     }
 
 
-    public interface MyListener {
+    public interface BlockClickListener {
         void onClickButton(ScriptModel.SpicaBlock block);
+    }
+
+    public interface OutSideClickListener{
+        void onClickOutSide();
     }
 
     // FragmentがActivityに追加されたら呼ばれるメソッド
@@ -129,9 +135,10 @@ public class BlockSelectFragment extends Fragment implements ScriptContract.Sele
 
         // contextクラスがMyListenerを実装しているかをチェックする
         super.onAttach(context);
-        if (context instanceof MyListener) {
+        if (context instanceof BlockClickListener) {
             // リスナーをここでセットするようにします
-            mListener = (MyListener) context;
+            mListener = (BlockClickListener) context;
+            outSideClickListener = (OutSideClickListener) context;
         }
     }
 
@@ -141,6 +148,7 @@ public class BlockSelectFragment extends Fragment implements ScriptContract.Sele
         super.onDetach();
         // 画面からFragmentが離れたあとに処理が呼ばれることを避けるためにNullで初期化しておく
         mListener = null;
+        outSideClickListener = null;
     }
 
     @Override

--- a/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/UI/Script/ScriptMainActivity.java
+++ b/app/src/main/java/com/t_robop/yuusuke/a01_spica_android/UI/Script/ScriptMainActivity.java
@@ -13,7 +13,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.MotionEvent;
-import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.Toast;
 import android.view.View;
@@ -26,18 +25,18 @@ import com.t_robop.yuusuke.a01_spica_android.util.UdpReceive;
 import com.t_robop.yuusuke.a01_spica_android.util.UdpSend;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import static com.t_robop.yuusuke.a01_spica_android.model.ScriptModel.SpicaBlock.FOR_END;
 import static com.t_robop.yuusuke.a01_spica_android.model.ScriptModel.SpicaBlock.IF_END;
 
-public class ScriptMainActivity extends AppCompatActivity implements ScriptContract.ScriptView, BlockSelectFragment.MyListener {
+public class ScriptMainActivity extends AppCompatActivity implements ScriptContract.ScriptView, BlockSelectFragment.BlockClickListener, BlockSelectFragment.OutSideClickListener {
 
     private ScriptContract.Presenter mScriptPresenter;
 
     private RecyclerView mScriptRecyclerView;
     private ScriptMainAdapter mScriptAdapter;
     private LinearLayoutManager mScriptLayoutManager;
+    FloatingActionButton fab;
 
     private BlockSelectFragment blockSelectFragment;
     private BlockDetailFragment blockDetailFragment;
@@ -60,7 +59,7 @@ public class ScriptMainActivity extends AppCompatActivity implements ScriptContr
         mScriptRecyclerView.setLayoutManager(mScriptLayoutManager);
         mScriptAdapter = new ScriptMainAdapter(this);
         mScriptRecyclerView.setAdapter(mScriptAdapter);
-
+        fab = findViewById(R.id.fab);
 
         /**
          * Presenterの初期化
@@ -170,7 +169,6 @@ public class ScriptMainActivity extends AppCompatActivity implements ScriptContr
         /**
          * fabがクリックされた時
          */
-        FloatingActionButton fab = findViewById(R.id.fab);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -222,6 +220,9 @@ public class ScriptMainActivity extends AppCompatActivity implements ScriptContr
      * Fragment生成メソッド
      */
     public void inflateFragment(ScriptModel scriptModel) {
+        fab.setVisibility(View.INVISIBLE);
+        fab.setEnabled(false);
+
         FragmentManager fragmentManager = getSupportFragmentManager();
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
 
@@ -256,6 +257,9 @@ public class ScriptMainActivity extends AppCompatActivity implements ScriptContr
         fragmentTransaction.remove(blockDetailFragment);
         fragmentTransaction.remove(blockSelectFragment);
         fragmentTransaction.commit();
+
+        fab.setVisibility(View.VISIBLE);
+        fab.setEnabled(true);
     }
 
 
@@ -268,6 +272,12 @@ public class ScriptMainActivity extends AppCompatActivity implements ScriptContr
         ScriptModel scriptModel = mScriptPresenter.getTargetScript();
         scriptModel.setBlock(block);
         inflateFragment(scriptModel);
+    }
+
+    @Override
+    public void onClickOutSide() {
+        fab.setVisibility(View.VISIBLE);
+        fab.setEnabled(true);
     }
 
     /**


### PR DESCRIPTION
現状、ブロック選択画面、詳細画面の表示中にfabを押せてしまう
押してしまうとそのままコマンド送信されてしまう

上記画面が表示中はfabを非表示・クリックできないようにした